### PR TITLE
1: Add Super-8 and 8mm

### DIFF
--- a/src/Calculate.elm
+++ b/src/Calculate.elm
@@ -59,3 +59,9 @@ framesPerFoot gauge =
 
         NinePtFive ->
             40
+
+        SuperEight ->
+            72
+
+        Eight ->
+            80

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -19,6 +19,12 @@ displayNameForGauge gauge =
         NinePtFive ->
             "9.5mm"
 
+        SuperEight ->
+            "Super-8"
+
+        Eight ->
+            "8mm"
+
 
 displayNameForSpeed : Speed -> String
 displayNameForSpeed speed =

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -16,11 +16,13 @@ type Gauge
     | TwentyEight
     | Sixteen
     | NinePtFive
+    | SuperEight
+    | Eight
 
 
 allGauges : List Gauge
 allGauges =
-    [ ThirtyFive, TwentyEight, Sixteen, NinePtFive ]
+    [ ThirtyFive, TwentyEight, Sixteen, NinePtFive, SuperEight, Eight ]
 
 
 type Control

--- a/src/View.elm
+++ b/src/View.elm
@@ -101,22 +101,11 @@ footer language =
 
 calculator : Model -> Html Msg
 calculator model =
-    let
-        makeGaugeButton g =
-            button
-                [ classList
-                    [ ( "button", True )
-                    , ( "is-primary", g == model.gauge )
-                    ]
-                , onClick <| ChangeGauge g
-                ]
-                [ text <| displayNameForGauge g ]
-    in
     div [ id "calculator" ]
         [ div [ id "basics", class "calculator" ]
             [ p [] [ text <| translate model.language ChooseStr ]
             , div [ id "options" ]
-                [ div [] (List.map makeGaugeButton allGauges)
+                [ renderSelect Sixteen ChangeGauge displayNameForGauge allGauges
                 , renderSelect TwentyFourFPS ChangeSpeed displayNameForSpeed allSpeeds
                 ]
             ]

--- a/styles/main.css
+++ b/styles/main.css
@@ -110,6 +110,10 @@ div.app-footer {
   margin: 0 auto;
 }
 
+.select {
+  margin: 0.5em;
+}
+
 .select:after {
   border-color: #00d1b2 !important; /* overriding Bulma */
 }
@@ -120,12 +124,6 @@ div.app-footer {
 
 .select select:focus {
   border-color: #00d1b2 !important; /* overriding Bulma */
-}
-
-@media (max-width: 767px) {
-  .select {
-    margin: 0.8em;
-  }
 }
 
 .calculator {
@@ -159,7 +157,7 @@ div.app-footer {
 @media (min-width: 768px) {
   #options {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: center;
     margin: 0 auto;
     max-width: 70%;
   }

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -83,6 +83,30 @@ all =
                     \_ ->
                         Expect.equal frameCount 2460
                 ]
+            , describe "gauge = Super-8, footage = 200', speed = 18fps" <|
+                let
+                    ( duration, frameCount ) =
+                        fromFootage EighteenFPS SuperEight 200
+                in
+                [ test "duration is correct" <|
+                    \_ ->
+                        Expect.equal duration 800
+                , test "framecount is correct" <|
+                    \_ ->
+                        Expect.equal frameCount 14400
+                ]
+            , describe "gauge = 8mm, footage = 25', speed = 16fps" <|
+                let
+                    ( duration, frameCount ) =
+                        fromFootage SixteenFPS Eight 25
+                in
+                [ test "duration is correct" <|
+                    \_ ->
+                        Expect.equal duration 125
+                , test "framecount is correct" <|
+                    \_ ->
+                        Expect.equal frameCount 2000
+                ]
             ]
         , describe "calculate duration, footage from frame count" <|
             [ describe "gauge = 35mm, frame count = 400, speed = 24fps" <|
@@ -135,6 +159,26 @@ all =
                 , test "footage is correct" <|
                     \_ -> Expect.equal (Round.round 3 footage) (toString 89.756)
                 ]
+            , describe "gauge = Super-8, frame count = 1840, speed = 18fps" <|
+                let
+                    ( duration, footage ) =
+                        fromFrameCount EighteenFPS SuperEight 1840
+                in
+                [ test "duration is correct" <|
+                    \_ -> Expect.equal (Round.round 3 duration) (toString 102.222)
+                , test "footage is correct" <|
+                    \_ -> Expect.equal (Round.round 3 footage) (toString 25.556)
+                ]
+            , describe "gauge = 8mm, frame count = 1840, speed = 16fps" <|
+                let
+                    ( duration, footage ) =
+                        fromFrameCount SixteenFPS Eight 1840
+                in
+                [ test "duration is correct" <|
+                    \_ -> Expect.equal duration 115
+                , test "footage is correct" <|
+                    \_ -> Expect.equal footage 23
+                ]
             ]
         , describe "calculate frame count, footage from duration" <|
             [ describe "gauge = 35mm, duration = 80 seconds, speed = 24fps" <|
@@ -186,6 +230,26 @@ all =
                     \_ -> Expect.equal frameCount 13824
                 , test "footage is correct" <|
                     \_ -> Expect.equal (Round.round 3 footage) (toString 674.341)
+                ]
+            , describe "gauge = Super-8, duration = 576 seconds, speed = 18fps" <|
+                let
+                    ( frameCount, footage ) =
+                        fromDuration EighteenFPS SuperEight 576
+                in
+                [ test "frame count is correct" <|
+                    \_ -> Expect.equal frameCount 10368
+                , test "footage is correct" <|
+                    \_ -> Expect.equal footage 144
+                ]
+            , describe "gauge = 8mm, duration = 176 seconds, speed = 16fps" <|
+                let
+                    ( frameCount, footage ) =
+                        fromDuration SixteenFPS Eight 176
+                in
+                [ test "frame count is correct" <|
+                    \_ -> Expect.equal frameCount 2816
+                , test "footage is correct" <|
+                    \_ -> Expect.equal footage 35.2
                 ]
             ]
         ]


### PR DESCRIPTION
Addressing #1 

The gauge options are now in a dropdown rather than a row of buttons:

![new-ui](https://user-images.githubusercontent.com/16832997/36370761-c1e88566-15c4-11e8-84d0-a48e4fb7da7d.png)
